### PR TITLE
166 link elements to extend scope

### DIFF
--- a/src/__tests__/html/walker.html
+++ b/src/__tests__/html/walker.html
@@ -136,12 +136,14 @@
     data-elb="l"
     data-elbaction="click"
     data-elb-l="k:v"
-    data-elbcontext=""
+    data-elbcontext="entity:link"
   >
-    <div data-elblink="wh:parent"><div data-elb-l="l0:0"></div></div>
+    <div data-elblink="wh:parent" data-elbcontext="parent:link">
+      <div data-elb-l="l0:0"></div>
+    </div>
   </div>
   <div data-elblink="wh:child"><div data-elb-l="l1:1"></div></div>
-  <div data-elblink="wh:child" data-elb-l="l2:2" data-elbcontext="">
+  <div data-elblink="wh:child" data-elb-l="l2:2" data-elbcontext="child:link">
     <div id="link-child" data-elb-l="l3:3" data-elbaction="click"></div>
   </div>
   <div data-elblink="bh"><div data-elb-l="no:pe"></div></div>

--- a/src/__tests__/html/walker.html
+++ b/src/__tests__/html/walker.html
@@ -131,13 +131,18 @@
 </div>
 
 <div>
-  <div id="link-parent" data-elb="l" data-elbaction="click" data-elb-l="k:v">
-    <div data-elblink="wh"><div data-elb-l="l0:0"></div></div>
+  <div
+    id="link-parent"
+    data-elb="l"
+    data-elbaction="click"
+    data-elb-l="k:v"
+    data-elbcontext=""
+  >
+    <div data-elblink="wh:parent"><div data-elb-l="l0:0"></div></div>
   </div>
-  <div data-elblink="wh"><div data-elb-l="l1:1"></div></div>
-  <div data-elblink="wh" data-elb-l="l2:2">
+  <div data-elblink="wh:child"><div data-elb-l="l1:1"></div></div>
+  <div data-elblink="wh:child" data-elb-l="l2:2" data-elbcontext="">
     <div id="link-child" data-elb-l="l3:3" data-elbaction="click"></div>
   </div>
-  <!-- <div data-elblink="wh" data-elb-l="no:pe"></div> -->
   <div data-elblink="bh"><div data-elb-l="no:pe"></div></div>
 </div>

--- a/src/__tests__/html/walker.html
+++ b/src/__tests__/html/walker.html
@@ -129,3 +129,15 @@
     <p data-elb-*="o:x"></p>
   </div>
 </div>
+
+<div>
+  <div id="link-parent" data-elb="l" data-elbaction="click" data-elb-l="k:v">
+    <div data-elblink="wh"><div data-elb-l="l0:0"></div></div>
+  </div>
+  <div data-elblink="wh"><div data-elb-l="l1:1"></div></div>
+  <div data-elblink="wh" data-elb-l="l2:2">
+    <div id="link-child" data-elb-l="l3:3" data-elbaction="click"></div>
+  </div>
+  <!-- <div data-elblink="wh" data-elb-l="no:pe"></div> -->
+  <div data-elblink="bh"><div data-elb-l="no:pe"></div></div>
+</div>

--- a/src/__tests__/walker.test.ts
+++ b/src/__tests__/walker.test.ts
@@ -248,6 +248,18 @@ describe('Walker', () => {
       },
     ]);
   });
+
+  test('Link', () => {
+    const data = { k: 'v', l0: 0, l1: 1, l2: 2, l3: 3 };
+
+    expect(
+      getEvents(getElem('link-parent'), Walker.Trigger.Click),
+    ).toMatchObject([{ entity: 'l', data }]);
+
+    // expect(
+    //   getEvents(getElem('link-child'), Walker.Trigger.Click),
+    // ).toMatchObject([{ entity: 'l', data }]);
+  });
 });
 
 function getElem(selector: string) {

--- a/src/__tests__/walker.test.ts
+++ b/src/__tests__/walker.test.ts
@@ -254,11 +254,21 @@ describe('Walker', () => {
 
     expect(
       getEvents(getElem('link-parent'), Walker.Trigger.Click),
-    ).toMatchObject([{ entity: 'l', data }]);
+    ).toMatchObject([{ entity: 'l', context: { entity: ['link', 0] }, data }]);
 
-    // expect(
-    //   getEvents(getElem('link-child'), Walker.Trigger.Click),
-    // ).toMatchObject([{ entity: 'l', data }]);
+    expect(
+      getEvents(getElem('link-child'), Walker.Trigger.Click),
+    ).toMatchObject([
+      {
+        entity: 'l',
+        context: {
+          child: ['link', 0],
+          parent: ['link', 1],
+          entity: ['link', 2],
+        },
+        data,
+      },
+    ]);
   });
 });
 

--- a/src/lib/walker.ts
+++ b/src/lib/walker.ts
@@ -216,10 +216,35 @@ function getEntity(
     type,
   );
 
+  // Add linked elements (data-elblink)
+  const elements = [element]; // Add entity element
+  const linkName = getElbAttributeName(prefix, IElbwalker.Commands.Link, false); // data-elblink
+  const linkSelector = `[${linkName}]`;
+  element.querySelectorAll(linkSelector).forEach((link) => {
+    // Get all linked elements
+    const linkId = getAttribute(link, linkName);
+    document
+      .querySelectorAll(`[${linkName}="${linkId}"]`)
+      .forEach((wormhole) => {
+        // Skip original elblink element and add only new ones
+        if (wormhole !== link) elements.push(wormhole);
+      });
+  });
+
+  // Get all property elements including from linked elements
+  let propertyElems: Array<Element> = [];
+  elements.forEach((elem) => {
+    // Also check for property on same level
+    if (elem.matches(entitySelector)) propertyElems.push(elem);
+    elem.querySelectorAll(entitySelector).forEach((elem) => {
+      propertyElems.push(elem);
+    });
+  });
+
   // Get properties
   let data: Walker.Properties = {};
   let genericProps: Walker.Properties = {};
-  element.querySelectorAll<HTMLElement>(entitySelector).forEach((child) => {
+  propertyElems.forEach((child) => {
     // Eventually override closer peroperties
     genericProps = assign(genericProps, getElbValues(prefix, child, '*'));
     data = assign(data, getElbValues(prefix, child, type));

--- a/src/types/elbwalker.d.ts
+++ b/src/types/elbwalker.d.ts
@@ -102,6 +102,7 @@ export namespace IElbwalker {
     Elb = 'elb',
     Globals = 'globals',
     Init = 'init',
+    Link = 'link',
     Prefix = 'data-elb',
     Run = 'run',
     User = 'user',


### PR DESCRIPTION
```html
<div>
  <div
    id="link-parent"
    data-elb="l"
    data-elbaction="click"
    data-elb-l="k:v"
    data-elbcontext="entity:link"
  >
    <div data-elblink="wh:parent" data-elbcontext="parent:link">
      <div data-elb-l="l0:0"></div>
    </div>
  </div>
  <div data-elblink="wh:child"><div data-elb-l="l1:1"></div></div>
  <div data-elblink="wh:child" data-elb-l="l2:2" data-elbcontext="child:link">
    <div id="link-child" data-elb-l="l3:3" data-elbaction="click"></div>
  </div>
  <div data-elblink="bh"><div data-elb-l="no:pe"></div></div>
</div>
```
becomes
```js
test('Link', () => {
  const data = { k: 'v', l0: 0, l1: 1, l2: 2, l3: 3 };

  expect(
    getEvents(getElem('link-parent'), Walker.Trigger.Click),
  ).toMatchObject([{ entity: 'l', context: { entity: ['link', 0] }, data }]);

  expect(
    getEvents(getElem('link-child'), Walker.Trigger.Click),
  ).toMatchObject([
    {
      entity: 'l',
      context: {
        child: ['link', 0],
        parent: ['link', 1],
        entity: ['link', 2],
      },
      data,
    },
  ]);
});
```